### PR TITLE
Update node-rsa

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cookie": "^0.2.2",
     "debug": "^2.2.0",
     "ft-poller": "^2.1.0",
-    "node-rsa": "^0.2.25"
+    "node-rsa": "^0.4.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
node-rsa 0.2 depends on lodash 3, which is flagging security warnings for us in whitesource (not sure how accessible this link is: https://saas.whitesourcesoftware.com/Wss/WSS.html#!libraryDetails;uuid=36515147-27ba-41d6-9b6e-d54821602e45;product=74865;orgToken=28d4f0db-96cc-4665-add5-7377a9059163)

You'd _hope_ there'd be no breaking changes between minor versions even pre-1.0.0. The changelog doesn't suggest anything heinous: https://www.npmjs.com/package/node-rsa#changelog
