### PR TITLE
Add filters to all steps for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,14 @@ workflows:
   version: 2
   build-and-release:
     jobs:
-      - install
+      - install:
+          filters:
+            <<: *only_version_tags
       - test:
           requires:
             - install
+          filters:
+            <<: *only_version_tags
       - release_npm:
           requires:
             - install


### PR DESCRIPTION
Fell foul of this classic CircleCI 2.0 problem.

If a job with tag filters dependent jobs don't have tag filters, the job will never run. This hasn't become apparent here yet as we haven't changed the code, so haven't tagged a release.

'https://github.com/Financial-Times/reliability-engineering/wiki/Circle-CI-2.0-Help-Sheet#using-git-branches-and-tags-with-workflows'