### PR TITLE
Unref the ft-poller setInterval

### DIFF
--- a/publickey.js
+++ b/publickey.js
@@ -25,7 +25,9 @@ module.exports = function (debug) {
 	});
 
 	const promise = flagsPoller.start({ initialRequest: true });
-	flagsPoller.poller.unref();
+	if (flagsPoller.poller) {
+		flagsPoller.poller.unref();
+	}
 
 	return function (opts) {
 		if (opts && opts.promise) {

--- a/publickey.js
+++ b/publickey.js
@@ -25,6 +25,7 @@ module.exports = function (debug) {
 	});
 
 	const promise = flagsPoller.start({ initialRequest: true });
+	flagsPoller.poller.unref();
 
 	return function (opts) {
 		if (opts && opts.promise) {


### PR DESCRIPTION
This prevents applications from stopping when running with Jest, in `node` mode, as the internal timer is still running and no unref'd.

This seems a better place to solve this than in ft-poller as it may be desirable to have ft-poller in the foreground in an application.

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Timeout

      at Poller.start (node_modules/ft-poller/src/poller.js:61:18)
      at Object.<anonymous>.module.exports (node_modules/@financial-times/s3o-middleware-utils/publickey.js:27:30)
      at Object.<anonymous> (node_modules/@financial-times/s3o-middleware-utils/authenticate.js:6:44)
```