### PR TITLE
Add RSA tests with actual RSA keypair implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # S3O-middleware-utils
-Utils to help middleware handle authenticating with [S3O](http://s3o.ft.com/docs)
+
+Utilities to help middleware handle authenticating with [S3O](http://s3o.ft.com/docs).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Financial-Times/S3O-middleware.git"
+    "url": "git+https://github.com/Financial-Times/s3o-middleware-utils"
   },
   "keywords": [
     "express",

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -16,8 +16,8 @@ chai.use(sinonChai);
 // https://github.com/Financial-Times/s3o/blob/992be3a122006210013da64aa2ceee65e03a479d/src/main/java/com/ft/s3o/util/KeyGenerator.java#L19
 const generateRSAKeyPair = () => new NodeRSA().generateKeyPair(512);
 
-const sign = (data, key) => {
-	const privatePem = key.exportKey('pkcs8-private-pem');
+const sign = (data, keyPair) => {
+	const privatePem = keyPair.exportKey('pkcs8-private-pem');
 	const s = crypto.createSign('sha1');
 	s.update(data);
 	s.end();
@@ -28,11 +28,11 @@ const keyFactory = sinon.stub();
 
 describe('lib/validate.js', () => {
 	let publicKey
-	let key
+	let keyPair
 
 	before(() => {
-		key = generateRSAKeyPair(4096)
-		publicKey = key.exportKey('pkcs8-public-der');
+		keyPair = generateRSAKeyPair(4096)
+		publicKey = keyPair.exportKey('pkcs8-public-der');
 	})
 
 	beforeEach(() => {
@@ -47,7 +47,7 @@ describe('lib/validate.js', () => {
 
 	describe('validator function', () => {
 		['', false, undefined, null].forEach((value) => {
-			it(`returns false if publicKey is ${value}`, () => {
+			it(`returns false if publicKey is "${value}"`, () => {
 				keyFactory.returns(value);
 
 				const validator = validatorFactory(keyFactory);
@@ -59,7 +59,7 @@ describe('lib/validate.js', () => {
 		});
 
 		it('returns false if the supplied key is empty', () => {
-			const token = sign('', key)
+			const token = sign('', keyPair)
 
 			const validator = validatorFactory(keyFactory);
 			const result = validator('charlie.briggs', token);
@@ -68,8 +68,8 @@ describe('lib/validate.js', () => {
 			result.should.equal(false);
 		});
 
-		it('returns false if supplied key does not validates against public key', () => {
-			const token = sign('charlie.briggs-lantern.ft.com', key)
+		it('returns false if supplied key does not validate against public key', () => {
+			const token = sign('charlie.briggs-lantern.ft.com', keyPair)
 
 			const validator = validatorFactory(keyFactory);
 			const result = validator('charlie.briggs', token);
@@ -79,7 +79,7 @@ describe('lib/validate.js', () => {
 		});
 
 		it('returns true if supplied key validates against the public key', () => {
-			const token = sign('charlie.briggs:lantern.ft.com', key)
+			const token = sign('charlie.briggs-lantern.ft.com', keyPair)
 
 			const validator = validatorFactory(keyFactory);
 			const result = validator('charlie.briggs-lantern.ft.com', token);

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -1,42 +1,43 @@
 /**
  * Basic spec for lib/validate.js
- *
- * N.b., I stub all the crypto stuff here because I have no idea how to generate a test token. -Æ.
  */
 
+const NodeRSA = require('node-rsa');
+const crypto = require('crypto');
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
-const proxyquire = require('proxyquire');
+const validatorFactory = require('../validate');
 
 chai.should();
 chai.use(sinonChai);
 
-// Stubs for node-rsa
-const rsaStub = sinon.stub();
-const exportKeyStub = sinon.stub();
-rsaStub.returns({ exportKey: exportKeyStub });
-exportKeyStub.returns('test-pem');
+// s3o uses rsa to generate key pairs
+// https://github.com/Financial-Times/s3o/blob/992be3a122006210013da64aa2ceee65e03a479d/src/main/java/com/ft/s3o/util/KeyGenerator.java#L19
+const generateRSAKeyPair = () => new NodeRSA().generateKeyPair(512);
 
-// Stubs for crypto
-const createVerifyStub = sinon.stub();
-const verifyStub = sinon.stub();
-const updateSpy = sinon.spy();
-createVerifyStub.returns({ update: updateSpy, verify: verifyStub });
-verifyStub.returns(true);
-
-const validatorFactory = proxyquire('../validate', {
-	'node-rsa': rsaStub,
-	'crypto': {
-		createVerify: createVerifyStub,
-	},
-});
+const sign = (data, key) => {
+	const privatePem = key.exportKey('pkcs8-private-pem');
+	const s = crypto.createSign('sha1');
+	s.update(data);
+	s.end();
+	return s.sign(privatePem);
+}
 
 const keyFactory = sinon.stub();
 
 describe('lib/validate.js', () => {
+	let publicKey
+	let key
+
+	before(() => {
+		key = generateRSAKeyPair(4096)
+		publicKey = key.exportKey('pkcs8-public-der');
+	})
+
 	beforeEach(() => {
 		keyFactory.reset();
+		keyFactory.returns(publicKey)
 	});
 
 	it('returns a function', () => {
@@ -45,31 +46,46 @@ describe('lib/validate.js', () => {
 	});
 
 	describe('validator function', () => {
-		it('returns false if publicKey is falsy', () => {
-			keyFactory.returns(false);
+		['', false, undefined, null].forEach((value) => {
+			it(`returns false if publicKey is ${value}`, () => {
+				keyFactory.returns(value);
+
+				const validator = validatorFactory(keyFactory);
+				const result = validator('test-key', 'test-token');
+
+				keyFactory.should.have.been.calledOnce;
+				result.should.equal(false);
+			});
+		});
+
+		it('returns false if the supplied key is empty', () => {
+			const token = sign('', key)
 
 			const validator = validatorFactory(keyFactory);
-			const result = validator('test-key', 'test-token');
+			const result = validator('charlie.briggs', token);
 
 			keyFactory.should.have.been.calledOnce;
 			result.should.equal(false);
 		});
 
-		it('returns true if supplied key validates against public key', () => {
-			keyFactory.returns('test-public-key');
+		it('returns false if supplied key does not validates against public key', () => {
+			const token = sign('charlie.briggs-lantern.ft.com', key)
 
 			const validator = validatorFactory(keyFactory);
-			const result = validator('test-key', 'test-token');
-			const testBuffer = new Buffer('test-public-key', 'base64');
+			const result = validator('charlie.briggs', token);
 
-      // This should be improved at some point.
-			result.should.equal(true);
 			keyFactory.should.have.been.calledOnce;
-			rsaStub.withArgs(testBuffer).should.have.been.calledOnce;
-			exportKeyStub.should.have.been.calledOnce;
-			createVerifyStub.should.have.been.calledOnce;
-			updateSpy.withArgs('test-key').should.have.been.calledOnce;
-			verifyStub.withArgs('test-pem', 'test-token').should.have.been.calledOnce;
+			result.should.equal(false);
+		});
+
+		it('returns true if supplied key validates against the public key', () => {
+			const token = sign('charlie.briggs:lantern.ft.com', key)
+
+			const validator = validatorFactory(keyFactory);
+			const result = validator('charlie.briggs-lantern.ft.com', token);
+
+			keyFactory.should.have.been.calledOnce;
+			result.should.equal(true);
 		});
 	});
 });

--- a/validate.js
+++ b/validate.js
@@ -5,13 +5,13 @@ const crypto = require('crypto');
 const NodeRSA = require('node-rsa');
 
 /**
- * Factory function for creating token validators
+ * Factory function for creating cryptographic signature validators
  *
  * @param  {string} s3oPublicKey S3O public key from public key service
  * @return {function}            Returns validator function
  */
 module.exports = function (s3oPublicKey) {
-	return function (key, signedToken) {
+	return function (object, signature) {
 		const publicKey = s3oPublicKey();
 		if (!publicKey) {
 			return false;
@@ -20,13 +20,13 @@ module.exports = function (s3oPublicKey) {
 		// Convert the publicKey from DER format to PEM format
 		// See: https://www.npmjs.com/package/node-rsa
 		const buffer = new Buffer(publicKey, 'base64');
-		const derKey = new NodeRSA(buffer, 'pkcs8-public-der');
-		const publicPem = derKey.exportKey('pkcs8-public-pem');
+		const publicDer = new NodeRSA(buffer, 'pkcs8-public-der');
+		const publicPem = publicDer.exportKey('pkcs8-public-pem');
 
 		// See: https://nodejs.org/api/crypto.html
 		const verifier = crypto.createVerify('sha1');
-		verifier.update(key);
+		verifier.update(object);
 
-		return verifier.verify(publicPem, signedToken, 'base64');
+		return verifier.verify(publicPem, signature, 'base64');
 	};
 };

--- a/validate.js
+++ b/validate.js
@@ -11,7 +11,7 @@ const NodeRSA = require('node-rsa');
  * @return {function}            Returns validator function
  */
 module.exports = function (s3oPublicKey) {
-	return function (key, token) {
+	return function (key, signedToken) {
 		const publicKey = s3oPublicKey();
 		if (!publicKey) {
 			return false;
@@ -27,6 +27,6 @@ module.exports = function (s3oPublicKey) {
 		const verifier = crypto.createVerify('sha1');
 		verifier.update(key);
 
-		return verifier.verify(publicPem, token, 'base64');
+		return verifier.verify(publicPem, signedToken, 'base64');
 	};
 };


### PR DESCRIPTION
Replaces the previous test which was entirely based around stubs.

Generates an RSA key pair based on the s3o implementation: 'https://github.com/Financial-Times/s3o/blob/992be3a122006210013da64aa2ceee65e03a479d/src/main/java/com/ft/s3o/util/KeyGenerator.java#L19'.
Signs a request as username-host as per s3o and verifies that validate returns true for matching keys.